### PR TITLE
README: Use process(), not parse()

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ async function markdownToProseMirror(markdown: string): Node {
         })),
       },
     } satisfies RemarkProseMirrorOptions)
-    .parse(markdown);
+    .process(markdown);
 
   return doc;
 }


### PR DESCRIPTION
Hi, thank you for your work!

I've updated the README to use `process()`, which will actually return a ProseMirror `Node`, instead of `parse()` which will return a syntax tree (`Root`).